### PR TITLE
Add solid cube and dense wireframe

### DIFF
--- a/src/vulkan_app/buffers.rs
+++ b/src/vulkan_app/buffers.rs
@@ -39,7 +39,7 @@ pub fn create_vertex_buffer(
     _indices: &QueueFamilyIndices,
     data: &[Vertex],
 ) -> (vk::Buffer, vk::DeviceMemory) {
-    let buffer_size = (std::mem::size_of::<Vertex>() * super::vertex::VERTICES.len()) as vk::DeviceSize;
+    let buffer_size = (std::mem::size_of::<Vertex>() * data.len()) as vk::DeviceSize;
     let (buffer, buffer_memory) = create_buffer(
         instance,
         device,

--- a/src/vulkan_app/commands.rs
+++ b/src/vulkan_app/commands.rs
@@ -77,6 +77,16 @@ impl VulkanApp {
             );
             self.device
                 .cmd_draw_indexed(command_buffer, INDICES.len() as u32, 1, 0, 0, 0);
+            self.device.cmd_bind_pipeline(
+                command_buffer,
+                vk::PipelineBindPoint::GRAPHICS,
+                self.wireframe_pipeline,
+            );
+            let wire_buffers = [self.wireframe_vertex_buffer];
+            let offsets = [0];
+            self.device
+                .cmd_bind_vertex_buffers(command_buffer, 0, &wire_buffers, &offsets);
+            self.device.cmd_draw(command_buffer, self.wireframe_vertex_count, 1, 0, 0);
             self.device.cmd_end_render_pass(command_buffer);
             self.device.end_command_buffer(command_buffer).unwrap();
         }

--- a/src/vulkan_app/swapchain.rs
+++ b/src/vulkan_app/swapchain.rs
@@ -160,6 +160,7 @@ impl VulkanApp {
                 self.device.destroy_framebuffer(*framebuffer, None);
             }
             self.device.destroy_pipeline(self.graphics_pipeline, None);
+            self.device.destroy_pipeline(self.wireframe_pipeline, None);
             self.device
                 .destroy_descriptor_pool(self.descriptor_pool, None);
             self.device
@@ -211,6 +212,12 @@ impl VulkanApp {
         );
         self.graphics_pipeline = graphics_pipeline;
         self.pipeline_layout = pipeline_layout;
+        self.wireframe_pipeline = pipeline::create_wireframe_pipeline(
+            &self.device,
+            self.render_pass,
+            self.swapchain_extent,
+            self.pipeline_layout,
+        );
         let (depth_image, depth_image_memory, depth_image_view) = images::create_depth_resources(
             &self.instance,
             &self.device,

--- a/src/vulkan_app/vertex.rs
+++ b/src/vulkan_app/vertex.rs
@@ -37,36 +37,36 @@ impl Vertex {
 
 pub const VERTICES: [Vertex; 8] = [
     Vertex {
-        pos: [-0.5, -0.5, 0.0],
-        color: [1.0, 0.0, 0.0],
+        pos: [-0.5, -0.5, 0.5],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
-        pos: [0.5, -0.5, 0.0],
-        color: [0.0, 1.0, 0.0],
+        pos: [0.5, -0.5, 0.5],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
-        pos: [0.5, 0.5, 0.0],
-        color: [0.0, 0.0, 1.0],
+        pos: [0.5, 0.5, 0.5],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
-        pos: [-0.5, 0.5, 0.0],
-        color: [1.0, 1.0, 1.0],
+        pos: [-0.5, 0.5, 0.5],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
         pos: [-0.5, -0.5, -0.5],
-        color: [1.0, 0.0, 0.0],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
         pos: [0.5, -0.5, -0.5],
-        color: [0.0, 1.0, 0.0],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
         pos: [0.5, 0.5, -0.5],
-        color: [0.0, 0.0, 1.0],
+        color: [0.298, 0.686, 0.314],
     },
     Vertex {
         pos: [-0.5, 0.5, -0.5],
-        color: [1.0, 1.0, 1.0],
+        color: [0.298, 0.686, 0.314],
     },
 ];
 
@@ -78,3 +78,25 @@ pub const INDICES: [u16; 36] = [
     3, 2, 6, 6, 7, 3, // top
     0, 5, 1, 5, 0, 4, // bottom
 ];
+
+pub fn generate_wireframe_vertices(divisions: u32) -> Vec<Vertex> {
+    let color = [0.298, 0.686, 0.314];
+    let mut vertices = Vec::new();
+    let step = 1.0 / divisions as f32;
+    for i in 0..=divisions {
+        let a = -0.5 + i as f32 * step;
+        for j in 0..=divisions {
+            let b = -0.5 + j as f32 * step;
+            // lines parallel to x
+            vertices.push(Vertex { pos: [-0.5, a, b], color });
+            vertices.push(Vertex { pos: [0.5, a, b], color });
+            // lines parallel to y
+            vertices.push(Vertex { pos: [b, -0.5, a], color });
+            vertices.push(Vertex { pos: [b, 0.5, a], color });
+            // lines parallel to z
+            vertices.push(Vertex { pos: [a, b, -0.5], color });
+            vertices.push(Vertex { pos: [a, b, 0.5], color });
+        }
+    }
+    vertices
+}


### PR DESCRIPTION
## Summary
- use a 1×1×1 cube with flat green color
- generate vertices for a 24×24×24 wireframe grid
- create a second pipeline to render the wireframe
- draw both the solid cube and the grid every frame

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688568065c408322bbaadcf42e25abfb